### PR TITLE
Add NMOS_CPP_ prefix to the CMake cache variables, e.g. BUILD_EXAMPLES, BUILD_TESTS, USE_CONAN

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -227,7 +227,7 @@ jobs:
       if: matrix.use_conan == false
       shell: bash
       run: |
-        echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DUSE_CONAN:BOOL=\"0\"" >> $GITHUB_ENV
+        echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_CONAN:BOOL=\"0\"" >> $GITHUB_ENV
     
     - name: ubuntu avahi setup
       if: runner.os == 'Linux' && matrix.install_mdns == false
@@ -626,7 +626,7 @@ jobs:
       if: matrix.use_conan == false
       shell: bash
       run: |
-        echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DUSE_CONAN:BOOL=\"0\"" >> $GITHUB_ENV
+        echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_CONAN:BOOL=\"0\"" >> $GITHUB_ENV
     
     - name: ubuntu avahi setup
       if: runner.os == 'Linux' && matrix.install_mdns == false

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -150,7 +150,7 @@
   if: matrix.use_conan == false
   shell: bash
   run: |
-    echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DUSE_CONAN:BOOL=\"0\"" >> $GITHUB_ENV
+    echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_CONAN:BOOL=\"0\"" >> $GITHUB_ENV
 
 - name: ubuntu avahi setup
   if: runner.os == 'Linux' && matrix.install_mdns == false

--- a/Development/CMakeLists.txt
+++ b/Development/CMakeLists.txt
@@ -4,15 +4,15 @@ cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 project(nmos-cpp)
 
 # enable or disable the example applications
-set(BUILD_EXAMPLES ON CACHE BOOL "Build example applications")
+set(NMOS_CPP_BUILD_EXAMPLES ON CACHE BOOL "Build example applications")
 
 # enable or disable the unit test suite
-set(BUILD_TESTS ON CACHE BOOL "Build test suite application")
+set(NMOS_CPP_BUILD_TESTS ON CACHE BOOL "Build test suite application")
 
 # enable or disable the LLDP support library (lldp)
 # and its additional dependencies
-set(BUILD_LLDP OFF CACHE BOOL "Build LLDP support library")
-mark_as_advanced(FORCE BUILD_LLDP)
+set(NMOS_CPP_BUILD_LLDP OFF CACHE BOOL "Build LLDP support library")
+mark_as_advanced(FORCE NMOS_CPP_BUILD_LLDP)
 
 # common config
 include(cmake/NmosCppCommon.cmake)
@@ -23,7 +23,7 @@ include(cmake/NmosCppDependencies.cmake)
 # nmos-cpp libraries
 include(cmake/NmosCppLibraries.cmake)
 
-if(BUILD_EXAMPLES)
+if(NMOS_CPP_BUILD_EXAMPLES)
     # nmos-cpp-node executable
     include(cmake/NmosCppNode.cmake)
 
@@ -31,7 +31,7 @@ if(BUILD_EXAMPLES)
     include(cmake/NmosCppRegistry.cmake)
 endif()
 
-if(BUILD_TESTS)
+if(NMOS_CPP_BUILD_TESTS)
     # nmos-cpp-test executable
     include(cmake/NmosCppTest.cmake)
 endif()

--- a/Development/cmake/NmosCppCommon.cmake
+++ b/Development/cmake/NmosCppCommon.cmake
@@ -1,7 +1,7 @@
-set(USE_CONAN ON CACHE BOOL "Use Conan to acquire dependencies")
-mark_as_advanced(FORCE USE_CONAN)
+set(NMOS_CPP_USE_CONAN ON CACHE BOOL "Use Conan to acquire dependencies")
+mark_as_advanced(FORCE NMOS_CPP_USE_CONAN)
 
-if(USE_CONAN)
+if(NMOS_CPP_USE_CONAN)
     include(cmake/NmosCppConan.cmake)
 endif()
 
@@ -28,7 +28,7 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if(BUILD_TESTS AND CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(NMOS_CPP_BUILD_TESTS AND CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     # note: to see the output of any failed tests, set CTEST_OUTPUT_ON_FAILURE=1 in the environment
     # and also remember that CMake doesn't add dependencies to the "test" (or "RUN_TESTS") target
     # so after changing code under test, it is important to "make all" (or build "ALL_BUILD")

--- a/Development/cmake/NmosCppDependencies.cmake
+++ b/Development/cmake/NmosCppDependencies.cmake
@@ -194,9 +194,9 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_link_libraries(DNSSD INTERFACE dns_sd)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     # find Bonjour for the mDNS support library (mdns)
-    set(MDNS_SYSTEM_BONJOUR OFF CACHE BOOL "Use dnssd.lib from the installed Bonjour SDK")
-    mark_as_advanced(FORCE MDNS_SYSTEM_BONJOUR)
-    if(MDNS_SYSTEM_BONJOUR)
+    set(NMOS_CPP_USE_SYSTEM_BONJOUR OFF CACHE BOOL "Use dnssd.lib from the installed Bonjour SDK")
+    mark_as_advanced(FORCE NMOS_CPP_USE_SYSTEM_BONJOUR)
+    if(NMOS_CPP_USE_SYSTEM_BONJOUR)
         # note: BONJOUR_INCLUDE and BONJOUR_LIB_DIR are now set by default to the location used by the Bonjour SDK Installer (bonjoursdksetup.exe) 3.0.0
         set(BONJOUR_INCLUDE "$ENV{PROGRAMFILES}/Bonjour SDK/Include" CACHE PATH "Bonjour SDK include directory")
         set(BONJOUR_LIB_DIR "$ENV{PROGRAMFILES}/Bonjour SDK/Lib/x64" CACHE PATH "Bonjour SDK library directory")
@@ -271,7 +271,7 @@ add_library(nmos-cpp::DNSSD ALIAS DNSSD)
 
 # PCAP library
 
-if(BUILD_LLDP)
+if(NMOS_CPP_BUILD_LLDP)
     # this target means the nmos-cpp libraries can link the same dependency
     # whether it's based on libpcap or winpcap
     add_library(PCAP INTERFACE)

--- a/Development/cmake/NmosCppLibraries.cmake
+++ b/Development/cmake/NmosCppLibraries.cmake
@@ -102,7 +102,7 @@ list(APPEND NMOS_CPP_TARGETS mdns)
 add_library(nmos-cpp::mdns ALIAS mdns)
 
 # LLDP support library
-if(BUILD_LLDP)
+if(NMOS_CPP_BUILD_LLDP)
     set(LLDP_SOURCES
         lldp/lldp.cpp
         lldp/lldp_frame.cpp
@@ -1017,7 +1017,7 @@ target_link_libraries(
     nmos-cpp::websocketpp
     nmos-cpp::json_schema_validator
     )
-if(BUILD_LLDP)
+if(NMOS_CPP_BUILD_LLDP)
     target_link_libraries(
         nmos-cpp PUBLIC
         nmos-cpp::lldp

--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -23,7 +23,7 @@ set(NMOS_CPP_TEST_CPPREST_TEST_SOURCES
 set(NMOS_CPP_TEST_CPPREST_TEST_HEADERS
     )
 
-if(BUILD_LLDP)
+if(NMOS_CPP_BUILD_LLDP)
     set(NMOS_CPP_TEST_LLDP_TEST_SOURCES
         lldp/test/lldp_test.cpp
         )
@@ -99,7 +99,7 @@ target_link_libraries(
     nmos-cpp::cpprestsdk
     nmos-cpp::Boost
     )
-if(BUILD_LLDP)
+if(NMOS_CPP_BUILD_LLDP)
     target_link_libraries(
         nmos-cpp-test
         nmos-cpp::lldp

--- a/Documents/Dependencies.md
+++ b/Documents/Dependencies.md
@@ -61,7 +61,7 @@ By default nmos-cpp uses [Conan](https://conan.io) to download most of its depen
 
 Now follow the [Getting Started](Getting-Started.md) instructions directly. Conan is used to download the rest of the dependencies.
 
-If you prefer not to use Conan, you must install Boost, WebSocket++, OpenSSL and C++ REST SDK as detailed below then call CMake with `-DUSE_CONAN:BOOL="0"` when building nmos-cpp.
+If you prefer not to use Conan, you must install Boost, WebSocket++, OpenSSL and C++ REST SDK as detailed below then call CMake with `-DNMOS_CPP_USE_CONAN:BOOL="0"` when building nmos-cpp.
 
 ### Boost C++ Libraries
 

--- a/Sandbox/conan-recipe/conanfile.py
+++ b/Sandbox/conan-recipe/conanfile.py
@@ -49,9 +49,9 @@ class NmosCppConan(ConanFile):
         # over any system-installed find-module packages
         self._cmake.definitions["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
         # no need to build unit tests
-        self._cmake.definitions["BUILD_TESTS"] = False
+        self._cmake.definitions["NMOS_CPP_BUILD_TESTS"] = False
         # the examples (nmos-cpp-registry and nmos-cpp-node) are useful utilities for users
-        self._cmake.definitions["BUILD_EXAMPLES"] = True
+        self._cmake.definitions["NMOS_CPP_BUILD_EXAMPLES"] = True
         # 'root' CMakeLists.txt is in Development
         self._cmake.configure(source_folder=os.path.join(self._source_subfolder, "Development"))
         return self._cmake


### PR DESCRIPTION
See https://github.com/garethsb/nmos-cpp/pull/2#issuecomment-896752599.

I searched a clone of https://github.com/conan-io/conan-center-index for CMake definitions of `BUILD_` vs. `<Prefix>BUILD_` variables. There are several hundred of each, so both seem acceptable. So therefore to improve the `add_subdirectory` case, as recommended in [Preparing project for CPM.cmake](https://github.com/cpm-cmake/CPM.cmake/wiki/Preparing-projects-for-CPM.cmake), I propose to prefix the cache variables that are most likely to conflict and one or two others for consistency.

`BUILD_TESTS` --> `NMOS_CPP_BUILD_TESTS`
`BUILD_EXAMPLES` --> `NMOS_CPP_BUILD_EXAMPLES`
`BUILD_LLDP` --> `NMOS_CPP_BUILD_LLDP`
`USE_CONAN` --> `NMOS_CPP_USE_CONAN`
and
`MDNS_SYSTEM_BONJOUR` --> `NMOS_CPP_USE_SYSTEM_BONJOUR`

For now I've left alone `SLOG_LOGGING_SEVERITY` and the `BONJOUR_` and `PCAP_` cache variables.
